### PR TITLE
Wyomind_Core is not available on public access

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -4,9 +4,5 @@
   See LICENSE.txt for license details.
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/Magento/Module/etc/module.xsd">
-    <module name="Wyomind_CronScheduler" setup_version="1.3.0">
-        <sequence>
-            <module name="Wyomind_Core"/>
-        </sequence>
-    </module>
+    <module name="Wyomind_CronScheduler" setup_version="1.3.0.1" />
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -4,5 +4,9 @@
   See LICENSE.txt for license details.
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/Magento/Module/etc/module.xsd">
-    <module name="Wyomind_CronScheduler" setup_version="1.3.0.1" />
+    <module name="Wyomind_CronScheduler" setup_version="1.3.0.1">
+        <sequence>
+            <module name="Magento_Cron"/>
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
Hi 

Wyomind_Core is not available for public access. So we can't get it in an external project.
Magento_Cron should be loaded before Wyomind_Cronscheduler