### PR TITLE
Timezone conversion is not present in UI for 2.2

### DIFF
--- a/view/adminhtml/ui_component/cronscheduler_task_listing.xml
+++ b/view/adminhtml/ui_component/cronscheduler_task_listing.xml
@@ -164,7 +164,7 @@
                 </item>
             </argument>
         </column>
-        <column name="created_at">
+        <column name="created_at" class="Magento\Ui\Component\Listing\Columns\Date">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="filter" xsi:type="string">dateRange</item>
@@ -176,7 +176,7 @@
                 </item>
             </argument>
         </column>
-        <column name="scheduled_at">
+        <column name="scheduled_at" class="Magento\Ui\Component\Listing\Columns\Date">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="filter" xsi:type="string">dateRange</item>
@@ -188,7 +188,7 @@
                 </item>
             </argument>
         </column>
-        <column name="executed_at">
+        <column name="executed_at" class="Magento\Ui\Component\Listing\Columns\Date">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="filter" xsi:type="string">dateRange</item>
@@ -200,7 +200,7 @@
                 </item>
             </argument>
         </column>
-        <column name="finished_at">
+        <column name="finished_at" class="Magento\Ui\Component\Listing\Columns\Date">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="filter" xsi:type="string">dateRange</item>


### PR DESCRIPTION
Magento 2.1: in table cron_schedule stored task timestamps in client time zone. For example New York time zone.
Magento 2.2: in table cron_schedule stored task timestamps in UTC.
As the result on Magento 2.2, on the page "tasks list" all dates displayed in UTC instead of client timezone.

Timeline rendered in client time zone.

This is the fix. However, it's most likely not compatible with 2.1 and 2.0 (I did not test it)

Please check if you can accept it and update version according to what you'll decide. 